### PR TITLE
Critical Point Fixes - Handling Pending Points on Request

### DIFF
--- a/views/myprofile.handlebars
+++ b/views/myprofile.handlebars
@@ -73,7 +73,7 @@
             <div class="card-body text-center">
               <h5 class="card-title">Available Points</h5>
               <p class="card-text">
-              <h2 class="text-center">{{user.points}}</h2>
+              <h2 class="text-center">{{availablePoints}}</h2>
               </p>
             </div>
           </div>
@@ -81,9 +81,19 @@
         <div class="col-xl-3 col-lg-3 col-md-3 col-sm-5 col-6 pb-2">
           <div class="card border-primary-bs h-100">
             <div class="card-body text-center">
-              <h5 class="card-title">Pending Points</h5>
+              <h5 class="card-title">Pending Purch Points</h5>
               <p class="card-text">
-              <h2 class="text-center">{{pendingPoints}}</h2>
+              <h2 class="text-center">{{pendingPointsPurchase}}</h2>
+              </p>
+            </div>
+          </div>
+        </div>
+                <div class="col-xl-3 col-lg-3 col-md-3 col-sm-5 col-6 pb-2">
+          <div class="card border-primary-bs h-100">
+            <div class="card-body text-center">
+              <h5 class="card-title">Pending Sale Points</h5>
+              <p class="card-text">
+              <h2 class="text-center">{{pendingPointsSale}}</h2>
               </p>
             </div>
           </div>


### PR DESCRIPTION
I was looking into a bug Glenn reported regarding the pending points not updating on the display which I thought was minor. As I was looking into it, I realized that the points were not checked properly when a user makes a request which is part of the required acceptance criteria for this project.

How it was operating:
When all books were loaded on the search page, the user points were simply pulled from the User record. This point total did not take into account any pending purchases the user had, aka points they had already "used" for a purchase that was not yet closed and reflected on their point total. This means that say I had 2 points and then I requested a book for 2 points, I now should not be able to request anymore books because my available points would be 0 but the system as it currently is would allow this and still thought I had 2 points available.

To correct this:
I created a common function to get the various user point totals which includes the total from their profile as is, their available points (total points + pending purchase points <- this is always negative), pending purchase points, pending sale points, total pending points (combines sale and purchase). I changed the my profile call to use this function so it'll properly display the point totals and I changed the select all books function to get the available points using this function rather than directly from the user profile.